### PR TITLE
GitHub Action to lint Python code for syntax errors

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,31 @@
+name: lint_python
+on:
+  pull_request:
+  push:
+  #  branches: [master]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    # strategy:
+    #  matrix:
+    #    os: [ubuntu-latest, macos-latest, windows-latest]
+    #    python-version: [2.7, 3.5, 3.6, 3.7, 3.8]  # , pypy3]
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-python@master
+      # with:
+      #   python-version: ${{ matrix.python-version }}
+      - run: pip install black codespell flake8 isort pytest reorder-python-imports
+      - run: black --check . || true
+      # - run: black --diff . || true
+      # - if: matrix.python-version >= 3.6
+      #  run: |
+      #    pip install black
+      #    black --check . || true
+      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      # isort and reorder-python-imports are two ways of doing the same thing
+      - run: isort --recursive . || true
+      - run: reorder-python-imports . || true
+      - run: pip install -r requirements.txt || true
+      - run: pytest . || true

--- a/keypair.py
+++ b/keypair.py
@@ -40,7 +40,7 @@ def rotate_keypair():
     init(autoreset=True)
     ck = Fore.CYAN + ' \N{heavy check mark}'
 
-`    ec2 = boto3.client('ec2')
+    ec2 = boto3.client('ec2')
 
     try:
         print('\n=> Checking for existing EC2 key pair: ' + key_name + ck)

--- a/keypair.py
+++ b/keypair.py
@@ -51,7 +51,7 @@ def rotate_keypair():
     else:
         gen_msg = '   Found! Generating a replacement key pair: '
         ec2.delete_key_pair(KeyName=key_name)
-`
+
     print('\n' + Fore.CYAN + gen_msg + key_name)
     keypair = ec2.create_key_pair(KeyName=key_name)
 


### PR DESCRIPTION
Output: https://github.com/cclauss/ec2-keypair-rotation/actions

Two stray [backticks on lines 43 and 54](https://github.com/DevOpsEtc/ec2-keypair-rotation/blob/master/keypair.py#L43-L54) are Python syntax errors.

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.